### PR TITLE
Fix temp user return value

### DIFF
--- a/grape_log_formatter.gemspec
+++ b/grape_log_formatter.gemspec
@@ -2,8 +2,6 @@
 
 $:.push File.expand_path("../lib", __FILE__)
 require 'grape_log_formatter/version'
-# $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-# require_relative "./lib/grape_log_formatter/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "grape_log_formatter"

--- a/grape_log_formatter.gemspec
+++ b/grape_log_formatter.gemspec
@@ -1,8 +1,9 @@
 # coding: utf-8
 
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require_relative "./lib/grape_log_formatter/version"
+$:.push File.expand_path("../lib", __FILE__)
+require 'grape_log_formatter/version'
+# $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+# require_relative "./lib/grape_log_formatter/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "grape_log_formatter"

--- a/lib/grape_log_formatter/loggers/custom_logging.rb
+++ b/lib/grape_log_formatter/loggers/custom_logging.rb
@@ -9,9 +9,10 @@ module GrapeLogFormatter
         user = sign_in_user || temp_user
         resource = request.env['api.endpoint'].instance_variable_get(:@options)[:for]
         action = request.env['api.endpoint'].instance_variable_get(:@options)[:path].first
+        temp_user = user.nil? ? NONE : user.is_temp_user?
         {
           user_id: (user && user.id) || NONE,
-          temp_user: user && user.is_temp_user? || NONE,
+          temp_user: temp_user,
           controller: resource,
           action: action,
         }.merge(error_message_of(response))

--- a/lib/grape_log_formatter/version.rb
+++ b/lib/grape_log_formatter/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogFormatter
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/grape_log_formatter/loggers/custom_logging_spec.rb
+++ b/spec/grape_log_formatter/loggers/custom_logging_spec.rb
@@ -72,7 +72,7 @@ describe GrapeLogFormatter::Loggers::CustomLogging do
       end
 
       it 'set temp_user false' do
-        expect(subject[:temp_user]).to eql NONE
+        expect(subject[:temp_user]).to eql false
       end
     end
 


### PR DESCRIPTION
1. Fix the return value of the `temp_user`
2. Fix the load path wihch is the old way to load file.

Implementation

1. For the temp user, when there is no user session we return NONE
if user signin then is true
if user is temp user then is false

2. require_relative which is not recommended in Ruby 1.9
push the expand file path and use `require` to load the version